### PR TITLE
fix: CQDG-1353 Fixed missing pipelines in graphql seq exp type

### DIFF
--- a/src/graphql/file/types/sequencingExperiment.ts
+++ b/src/graphql/file/types/sequencingExperiment.ts
@@ -32,6 +32,7 @@ const SequencingExperimentType = new GraphQLObjectType({
     labAliquotID: { type: GraphQLString },
     ldm_sample_id: { type: GraphQLString },
     owner: { type: GraphQLString },
+    pipelines: { type: new GraphQLList(GraphQLString) },
     platform: { type: GraphQLString },
     read_length: { type: GraphQLString },
     run_alias: { type: GraphQLString },


### PR DESCRIPTION
Portal is getting this error when on the file explorer page :
```
Cannot query field "pipelines" on type "SequencingExperimentType".
```