### PR TITLE
fix: CQDG-1384 Added target capture kit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+# Pull Request Title
+
+## 📌 Context
+
+<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
+
+## 📝 Changes
+
+<!-- List the main changes in this PR. -->
+
+-
+
+## ☑️ TO-DOs
+
+<!-- Tasks that still need to be completed before merging. -->
+
+- [ ] 
+
+## 🧪 Tests
+
+<!-- Describe any new or updated tests, how to run them, and relevant results. -->
+
+-
+
+## 🔗 Related Issues
+
+<!-- Begin JIRA Issues -->
+
+<!-- End JIRA Issues -->
+
+## 👀 Notes for Reviewers
+
+<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->
+
+- 

--- a/src/graphql/biospecimen/types/biospecimenAgg.ts
+++ b/src/graphql/biospecimen/types/biospecimenAgg.ts
@@ -29,6 +29,7 @@ const BiospecimenAgg = new GraphQLObjectType({
     files__sequencing_experiment__analysis_id: { type: AggregationsType },
     files__sequencing_experiment__bio_informatic_analysis: { type: AggregationsType },
     files__sequencing_experiment__capture_kit: { type: AggregationsType },
+    files__sequencing_experiment__target_capture_kit: { type: AggregationsType },
     files__sequencing_experiment__experimental_strategy: { type: AggregationsType },
     files__sequencing_experiment__gcnv: { type: AggregationsType },
     files__sequencing_experiment__genome_build: { type: AggregationsType },

--- a/src/graphql/file/types/fileAgg.ts
+++ b/src/graphql/file/types/fileAgg.ts
@@ -263,6 +263,7 @@ const FileAgg = new GraphQLObjectType({
     sequencing_experiment__analysis_id: { type: AggregationsType },
     sequencing_experiment__bio_informatic_analysis: { type: AggregationsType },
     sequencing_experiment__capture_kit: { type: AggregationsType },
+    sequencing_experiment__target_capture_kit: { type: AggregationsType },
     sequencing_experiment__experimental_strategy: { type: AggregationsType },
     sequencing_experiment__gcnv: { type: AggregationsType },
     sequencing_experiment__genome_build: { type: AggregationsType },

--- a/src/graphql/file/types/sequencingExperiment.ts
+++ b/src/graphql/file/types/sequencingExperiment.ts
@@ -24,6 +24,7 @@ const SequencingExperimentType = new GraphQLObjectType({
     analysis_id: { type: GraphQLString },
     bio_informatic_analysis: { type: GraphQLString },
     capture_kit: { type: GraphQLString },
+    target_capture_kit: { type: GraphQLString },
     experimental_strategy: { type: GraphQLString },
     experimental_strategy_1: { type: ExperimentalStrategyType },
     gcnv: { type: GraphQLString },

--- a/src/graphql/participant/types/participantAgg.ts
+++ b/src/graphql/participant/types/participantAgg.ts
@@ -64,6 +64,7 @@ const ParticipantAgg = new GraphQLObjectType({
     files__sequencing_experiment__analysis_id: { type: AggregationsType },
     files__sequencing_experiment__bio_informatic_analysis: { type: AggregationsType },
     files__sequencing_experiment__capture_kit: { type: AggregationsType },
+    files__sequencing_experiment__target_capture_kit: { type: AggregationsType },
     files__sequencing_experiment__experimental_strategy: { type: AggregationsType },
     files__sequencing_experiment__gcnv: { type: AggregationsType },
     files__sequencing_experiment__genome_build: { type: AggregationsType },


### PR DESCRIPTION
## 📌 Context

This PR adds the `target_capture_kit` value to the response. Previously it was `capture_kit`. 
**NOTE : `capture_kit` will need to be removed in the future but was kept in case any studies are still using it.**

## 📝 Changes

- Added `target_capture_kit`

## 🔗 Related Issues

- [CQDG-1384](https://ferlab-crsj.atlassian.net/browse/CQDG-1384?atlOrigin=eyJpIjoiZDU4M2QxYjE4ZDY4NGVjMzljNDg3OGIzYjI5YzJhNTEiLCJwIjoiaiJ9)

[CQDG-1384]: https://ferlab-crsj.atlassian.net/browse/CQDG-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ